### PR TITLE
スクリーンリーダーを利用しているとき、 START ボタンを押せるようにする

### DIFF
--- a/src/html/inc/title.pug
+++ b/src/html/inc/title.pug
@@ -3,4 +3,4 @@
     img(src="img/logo.png" alt="電脳麻将")
   .version
   .loading Loading data...
-  .start.hide START
+  .start.hide(role="button" tabindex="0") START


### PR DESCRIPTION
## 経緯
私は視覚障害があり、 [スクリーンリーダー](https://ja.wikipedia.org/wiki/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%83%AA%E3%83%BC%E3%83%80%E3%83%BC) を利用しています。
先ほど、麻雀の練習用にこのアプリケーションを使おうとしたところ、最初の START ボタンが、スクリーンリーダーにボタンとして認識されず、なかなか押せませんでした。
ベースが html5 + js なので、うまくすれば使えるようになるかなと思い、手始めにちょっとした変更を入れてみました。このリポジトリでのコントリビューションに対する方針が許せば、アクセシビリティを改善するPRをレビュー&取り込んでいただけると大変助かります。

## 変更内容
STARTボタンに [button role](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles/button_role) を付けました。これにより、画面表示に影響することなく、 div 要素を支援技術に button として認識させることができます。(これがないと、 START が押せるのかどうか、読み上げでは分からない場合があります)
追加で、タブキーを押したときに START ボタンにフォーカスが乗るように、 tabindex=0 を付けました。こちらは既存の挙動に若干影響するので、タブキーでフォーカスするのはちょっと…ということであれば、消しても問題はありません。
